### PR TITLE
ad volume range

### DIFF
--- a/components/tas5805m/audio_dac.py
+++ b/components/tas5805m/audio_dac.py
@@ -58,8 +58,8 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_MIXER_MODE, default="STEREO"): cv.enum(
                         MIXER_MODES, upper=True
             ),
-            cv.Optional(CONF_MIN_VOLUME, default=0): cv.int_range(0, 254),
-            cv.Optional(CONF_MAX_VOLUME, default=254): cv.int_range(0, 254),
+            cv.Optional(CONF_MIN_VOLUME, default=254): cv.int_range(0, 254),
+            cv.Optional(CONF_MAX_VOLUME, default=0): cv.int_range(0, 254),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)

--- a/components/tas5805m/audio_dac.py
+++ b/components/tas5805m/audio_dac.py
@@ -58,8 +58,8 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_MIXER_MODE, default="STEREO"): cv.enum(
                         MIXER_MODES, upper=True
             ),
-            cv.Optional(CONF_MIN_VOLUME, default=0): cv.int_range(0, 254)),
-            cv.Optional(CONF_MAX_VOLUME, default=254): cv.int_range(0, 254)),
+            cv.Optional(CONF_MIN_VOLUME, default=0): cv.int_range(0, 254),
+            cv.Optional(CONF_MAX_VOLUME, default=254): cv.int_range(0, 254),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)

--- a/components/tas5805m/audio_dac.py
+++ b/components/tas5805m/audio_dac.py
@@ -16,6 +16,9 @@ CONF_ANALOG_GAIN = "analog_gain"
 CONF_DAC_MODE = "dac_mode"
 CONF_MIXER_MODE = "mixer_mode"
 
+CONF_MIN_VOLUME = "min_volume"
+CONF_MAX_VOLUME = "max_volume"
+
 CONF_TAS5805M_ID = "tas5805m_id"
 
 tas5805m_ns = cg.esphome_ns.namespace("tas5805m")
@@ -55,6 +58,8 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_MIXER_MODE, default="STEREO"): cv.enum(
                         MIXER_MODES, upper=True
             ),
+            cv.Optional(CONF_MIN_VOLUME, default=0): cv.int_range(0, 254)),
+            cv.Optional(CONF_MAX_VOLUME, default=254): cv.int_range(0, 254)),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -70,3 +75,5 @@ async def to_code(config):
     cg.add(var.config_analog_gain(config[CONF_ANALOG_GAIN]))
     cg.add(var.config_dac_mode(config[CONF_DAC_MODE]))
     cg.add(var.config_mixer_mode(config[CONF_MIXER_MODE]))
+    cg.add(var.config_min_volume(config[CONF_MIN_VOLUME]))
+    cg.add(var.config_max_volume(config[CONF_MAX_VOLUME]))

--- a/components/tas5805m/tas5805m.cpp
+++ b/components/tas5805m/tas5805m.cpp
@@ -109,16 +109,16 @@ void Tas5805mComponent::dump_config() {
 
 bool Tas5805mComponent::set_volume(float volume) {
   float new_volume = clamp(volume, 0.0f, 1.0f);
-  uint8_t raw_volume = remap<uint8_t, float>(new_volume, 0.0f, 1.0f, this->tas5805m_state_.max_volume, this->tas5805m_state_.min_volume);
+  uint8_t raw_volume = remap<uint8_t, float>(new_volume, 0.0f, 1.0f, max_volume, min_volume);
   if (!this->set_digital_volume(raw_volume)) return false;
-  ESP_LOGD(TAG, "  Volume changed to: %2.0f%%", new_volume*100);
+  ESP_LOGD(TAG, "  Volume changed to: %2.0f%% (raw: %3d)", new_volume*100, raw_volume);
   return true;
 }
 
 float Tas5805mComponent::volume() {
   uint8_t raw_volume;
   get_digital_volume(&raw_volume);
-  return remap<float, uint8_t>(raw_volume, this->tas5805m_state_.max_volume, this->tas5805m_state_.min_volume, 0.0f, 1.0f);
+  return remap<float, uint8_t>(raw_volume, max_volume, min_volume, 0.0f, 1.0f);
 }
 
 bool Tas5805mComponent::set_mute_off() {

--- a/components/tas5805m/tas5805m.cpp
+++ b/components/tas5805m/tas5805m.cpp
@@ -109,7 +109,7 @@ void Tas5805mComponent::dump_config() {
 
 bool Tas5805mComponent::set_volume(float volume) {
   float new_volume = clamp(volume, 0.0f, 1.0f);
-  uint8_t raw_volume = remap<uint8_t, float>(new_volume, 0.0f, 1.0f, this->tas5805m_state_.max_volume, this->tas5805m_state_.min_volume);
+  uint8_t raw_volume = remap<uint8_t, float>(new_volume, 0.0f, 1.0f, this->tas5805m_state_.min, this->tas5805m_state_.max_volume);
   if (!this->set_digital_volume(raw_volume)) return false;
   ESP_LOGD(TAG, "  Volume changed to: %2.0f%% (raw: %3d)", new_volume*100, raw_volume);
   return true;
@@ -118,7 +118,7 @@ bool Tas5805mComponent::set_volume(float volume) {
 float Tas5805mComponent::volume() {
   uint8_t raw_volume;
   get_digital_volume(&raw_volume);
-  return remap<float, uint8_t>(raw_volume, this->tas5805m_state_.max_volume, this->tas5805m_state_.min_volume, 0.0f, 1.0f);
+  return remap<float, uint8_t>(raw_volume, this->tas5805m_state_.min_volume, this->tas5805m_state_.max_volume, 0.0f, 1.0f);
 }
 
 bool Tas5805mComponent::set_mute_off() {

--- a/components/tas5805m/tas5805m.cpp
+++ b/components/tas5805m/tas5805m.cpp
@@ -109,7 +109,7 @@ void Tas5805mComponent::dump_config() {
 
 bool Tas5805mComponent::set_volume(float volume) {
   float new_volume = clamp(volume, 0.0f, 1.0f);
-  uint8_t raw_volume = remap<uint8_t, float>(new_volume, 0.0f, 1.0f, 254, 0);
+  uint8_t raw_volume = remap<uint8_t, float>(new_volume, 0.0f, 1.0f, this->tas5805m_state_.max_volume, this->tas5805m_state_.min_volume);
   if (!this->set_digital_volume(raw_volume)) return false;
   ESP_LOGD(TAG, "  Volume changed to: %2.0f%%", new_volume*100);
   return true;
@@ -118,7 +118,7 @@ bool Tas5805mComponent::set_volume(float volume) {
 float Tas5805mComponent::volume() {
   uint8_t raw_volume;
   get_digital_volume(&raw_volume);
-  return remap<float, uint8_t>(raw_volume, 254, 0, 0.0f, 1.0f);
+  return remap<float, uint8_t>(raw_volume, this->tas5805m_state_.max_volume, this->tas5805m_state_.min_volume, 0.0f, 1.0f);
 }
 
 bool Tas5805mComponent::set_mute_off() {

--- a/components/tas5805m/tas5805m.cpp
+++ b/components/tas5805m/tas5805m.cpp
@@ -109,7 +109,7 @@ void Tas5805mComponent::dump_config() {
 
 bool Tas5805mComponent::set_volume(float volume) {
   float new_volume = clamp(volume, 0.0f, 1.0f);
-  uint8_t raw_volume = remap<uint8_t, float>(new_volume, 0.0f, 1.0f, this->tas5805m_state_.min, this->tas5805m_state_.max_volume);
+  uint8_t raw_volume = remap<uint8_t, float>(new_volume, 0.0f, 1.0f, this->tas5805m_state_.min_volume, this->tas5805m_state_.max_volume);
   if (!this->set_digital_volume(raw_volume)) return false;
   ESP_LOGD(TAG, "  Volume changed to: %2.0f%% (raw: %3d)", new_volume*100, raw_volume);
   return true;

--- a/components/tas5805m/tas5805m.cpp
+++ b/components/tas5805m/tas5805m.cpp
@@ -109,7 +109,7 @@ void Tas5805mComponent::dump_config() {
 
 bool Tas5805mComponent::set_volume(float volume) {
   float new_volume = clamp(volume, 0.0f, 1.0f);
-  uint8_t raw_volume = remap<uint8_t, float>(new_volume, 0.0f, 1.0f, max_volume, min_volume);
+  uint8_t raw_volume = remap<uint8_t, float>(new_volume, 0.0f, 1.0f, this->tas5805m_state_.max_volume, this->tas5805m_state_.min_volume);
   if (!this->set_digital_volume(raw_volume)) return false;
   ESP_LOGD(TAG, "  Volume changed to: %2.0f%% (raw: %3d)", new_volume*100, raw_volume);
   return true;
@@ -118,7 +118,7 @@ bool Tas5805mComponent::set_volume(float volume) {
 float Tas5805mComponent::volume() {
   uint8_t raw_volume;
   get_digital_volume(&raw_volume);
-  return remap<float, uint8_t>(raw_volume, max_volume, min_volume, 0.0f, 1.0f);
+  return remap<float, uint8_t>(raw_volume, this->tas5805m_state_.max_volume, this->tas5805m_state_.min_volume, 0.0f, 1.0f);
 }
 
 bool Tas5805mComponent::set_mute_off() {

--- a/components/tas5805m/tas5805m.h
+++ b/components/tas5805m/tas5805m.h
@@ -24,6 +24,8 @@ class Tas5805mComponent : public audio_dac::AudioDac, public Component, public i
   void config_analog_gain(float analog_gain) { this->tas5805m_state_.analog_gain = analog_gain; }
   void config_dac_mode(DacMode dac_mode) {this->tas5805m_state_.dac_mode = dac_mode; }
   void config_mixer_mode(MixerMode mixer_mode) {this->tas5805m_state_.mixer_mode = mixer_mode; }
+  void config_min_volume(uint8_t min_volume) { this->tas5805m_state_.min_volume = min_volume; }
+  void config_max_volume(uint8_t max_volume) { this->tas5805m_state_.max_volume = max_volume; }
 
   float volume() override;
   bool set_volume(float value) override;

--- a/components/tas5805m/tas5805m.h
+++ b/components/tas5805m/tas5805m.h
@@ -102,6 +102,8 @@ class Tas5805mComponent : public audio_dac::AudioDac, public Component, public i
     bool              eq_enabled{false};
     int8_t            eq_gain[TAS5805M_EQ_BANDS]{0};
     //bool              eq_gain_set[TAS5805M_EQ_BANDS]{false};
+    uint8_t           min_volume;
+    uint8_t           max_volume;
     #endif
 
    } tas5805m_state_;


### PR DESCRIPTION
Hi @mrtoy-me,

this just a proposal, to add min_volume and max_volume settings to config yaml for the DAC. 

At least with my speakers there is nothing audible in the lower half of the volume slider, where as 
at the end of the upper half it's makes really large steps and is hard to control with a touch-interface 
(it's fine when using a mouse on the desktop).

What is irritating is the fact, that 254 is the "minimal volume" where as "0" is maximum volume. 

So maybe it would be better to add some logic to make configuration more intuitive.

Anyway, let me know what you think.
